### PR TITLE
[안재관 | 0423] Feature/55 부서 수정 DTO 설계 및 중복 검사 로직 추가

### DIFF
--- a/src/main/java/com/team01/hrbank/dto/department/DepartmentUpdateRequest.java
+++ b/src/main/java/com/team01/hrbank/dto/department/DepartmentUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
-public record DepartmentCreateRequest(
+public record DepartmentUpdateRequest(
     @NotBlank(message = "부서명은 필수입니다.")
     @Size(max = 30, message = "부서명은 30자를 초과할 수 없습니다.")
     String name,

--- a/src/main/java/com/team01/hrbank/entity/Department.java
+++ b/src/main/java/com/team01/hrbank/entity/Department.java
@@ -29,4 +29,10 @@ public class Department extends BaseUpdatableEntity{
         this.description = description;
         this.establishedDate = establishedDate;
     }
+
+    public void update(String name, String description, LocalDate establishedDate) {
+        this.name = name;
+        this.description = description;
+        this.establishedDate = establishedDate;
+    }
 }

--- a/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
+++ b/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
@@ -4,6 +4,10 @@ import com.team01.hrbank.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+
     boolean existsByName(String name);
+
+    // 수정 시, 자기 자신(ID)을 제외한 중복 체크
+    boolean existsByNameAndIdNot(String name, Long id);
 
 }

--- a/src/main/java/com/team01/hrbank/service/DepartmentService.java
+++ b/src/main/java/com/team01/hrbank/service/DepartmentService.java
@@ -2,8 +2,11 @@ package com.team01.hrbank.service;
 
 import com.team01.hrbank.dto.department.DepartmentCreateRequest;
 import com.team01.hrbank.dto.department.DepartmentDto;
+import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
 
 public interface DepartmentService {
 
     DepartmentDto createDepartment(DepartmentCreateRequest request);
+
+    DepartmentDto updateDepartment(Long departmentId, DepartmentUpdateRequest request);
 }

--- a/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
@@ -2,6 +2,7 @@ package com.team01.hrbank.service.impl;
 
 import com.team01.hrbank.dto.department.DepartmentCreateRequest;
 import com.team01.hrbank.dto.department.DepartmentDto;
+import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
 import com.team01.hrbank.entity.Department;
 import com.team01.hrbank.exception.DuplicateException;
 import com.team01.hrbank.mapper.DepartmentMapper;
@@ -18,6 +19,7 @@ public class DepartmentServiceImpl implements DepartmentService {
     private final DepartmentRepository departmentRepository;
     private final DepartmentMapper departmentMapper;
 
+    @Override
     @Transactional
     public DepartmentDto createDepartment(DepartmentCreateRequest request) {
 
@@ -34,7 +36,20 @@ public class DepartmentServiceImpl implements DepartmentService {
 
         // 나중에 0L 부분을 실제 직원을 조회한 값으로 바꿔야 합니다. + 조회 로직까지 추가
         return departmentMapper.toDto(savedDepartment, 0L);
-
     }
 
+    @Override
+    @Transactional
+    public DepartmentDto updateDepartment(Long departmentId, DepartmentUpdateRequest request) {
+        Department department = departmentRepository.findById(departmentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다. ID:" + departmentId));
+
+        if (departmentRepository.existsByNameAndIdNot(request.name(), departmentId)) {
+            throw new DuplicateException(request.name());
+        }
+
+        department.update(request.name(), request.description(), request.establishedDate());
+
+        return departmentMapper.toDto(department, 0L);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #55 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 수정 요청을 처리하기 위한 DTO 클래스를 설계하고, 유효성 검증 어노테이션을 적용
- 부서명, 설명, 설립일 필드에 대한 필수 값 및 형식 검증을 구현
- 현재 수정 중인 부서를 제외한 중복 부서명이 존재할 경우 예외를 발생

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- DepartmentUpdateRequest DTO 클래스 생성
- 필드 정의: name, description, establishedDate
- 유효성 검증 어노테이션 작성
  - `@NotBlank, @Size, @PastOrPresent` 등 적용
- 서비스 내 중복 이름 검사 로직 구현
  - existsByNameAndIdNot(String name, Long id) 활용
  - 중복 시 예외 발생 (DuplicateException 또는 IllegalArgumentException)
- 수정 로직에서 현재 부서를 제외한 이름 중복 검증 처리
