### PR TITLE
[안재관 | 0423] Feature/59 부서 수정 API 및 예외 처리 로직 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/controller/DepartmentController.java
+++ b/src/main/java/com/team01/hrbank/controller/DepartmentController.java
@@ -2,10 +2,13 @@ package com.team01.hrbank.controller;
 
 import com.team01.hrbank.dto.department.DepartmentCreateRequest;
 import com.team01.hrbank.dto.department.DepartmentDto;
+import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
 import com.team01.hrbank.service.DepartmentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,15 @@ public class DepartmentController {
 
         DepartmentDto response = departmentService.createDepartment(request);
         return ResponseEntity.ok(response); // 200 OK 응답
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<DepartmentDto> updateDepartment(
+        @PathVariable Long id,
+        @Valid @RequestBody DepartmentUpdateRequest request) {
+
+        DepartmentDto response = departmentService.updateDepartment(id, request);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/team01/hrbank/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/team01/hrbank/controller/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.team01.hrbank.controller.advice;
 
 import com.team01.hrbank.dto.error.ErrorResponse;
 import com.team01.hrbank.exception.DuplicateException;
+import com.team01.hrbank.exception.EntityNotFoundException;
 import java.time.Instant;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -54,5 +55,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(error);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        ErrorResponse error = new ErrorResponse(
+            Instant.now(),
+            HttpStatus.NOT_FOUND.value(),
+            "찾을 수 없습니다.",
+            ex.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
 }

--- a/src/main/java/com/team01/hrbank/exception/EntityNotFoundException.java
+++ b/src/main/java/com/team01/hrbank/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.team01.hrbank.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String entityName, Object id) {
+        super(entityName + "을(를) 찾을 수 없습니다. ID: " + id);
+    }
+}

--- a/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
@@ -5,6 +5,7 @@ import com.team01.hrbank.dto.department.DepartmentDto;
 import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
 import com.team01.hrbank.entity.Department;
 import com.team01.hrbank.exception.DuplicateException;
+import com.team01.hrbank.exception.EntityNotFoundException;
 import com.team01.hrbank.mapper.DepartmentMapper;
 import com.team01.hrbank.repository.DepartmentRepository;
 import com.team01.hrbank.service.DepartmentService;
@@ -18,6 +19,7 @@ public class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     private final DepartmentMapper departmentMapper;
+    private static final String DEPARTMENT = "부서";
 
     @Override
     @Transactional
@@ -42,7 +44,7 @@ public class DepartmentServiceImpl implements DepartmentService {
     @Transactional
     public DepartmentDto updateDepartment(Long departmentId, DepartmentUpdateRequest request) {
         Department department = departmentRepository.findById(departmentId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다. ID:" + departmentId));
+            .orElseThrow(() -> new EntityNotFoundException(DEPARTMENT, departmentId));
 
         if (departmentRepository.existsByNameAndIdNot(request.name(), departmentId)) {
             throw new DuplicateException(request.name());


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #59 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 수정 요청을 처리하는 컨트롤러 메서드를 작성하고, 수정 시 발생할 수 있는 예외 처리 로직을 구현
- 존재하지 않는 부서 ID 요청 시 404 예외 처리, 중복 이름 및 유효성 검증 실패 시 400 응답을 반환하도록 설정

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- PATCH /api/departments/{id} 컨트롤러 메서드 작성
  - `@PathVariable Long id, @Valid @RequestBody DepartmentUpdateRequest` 처리
  - 수정 후 DepartmentDto 반환
- 존재하지 않는 부서 ID 요청 시 404 예외 발생 및 처리
  - 예외 클래스 필요 시 정의 (DepartmentNotFoundException 등)
- GlobalExceptionHandler에 404 예외 처리 추가
