### PR TITLE
[안재관 | 0423] Feature/64 부서 삭제 API 및 예외 처리 로직 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/controller/DepartmentController.java
+++ b/src/main/java/com/team01/hrbank/controller/DepartmentController.java
@@ -7,6 +7,7 @@ import com.team01.hrbank.service.DepartmentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,6 +37,12 @@ public class DepartmentController {
 
         DepartmentDto response = departmentService.updateDepartment(id, request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDepartment(@PathVariable Long id) {
+        departmentService.deleteDepartment(id);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/team01/hrbank/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/team01/hrbank/controller/advice/GlobalExceptionHandler.java
@@ -43,7 +43,19 @@ public class GlobalExceptionHandler {
             .body(error);
     }
 
-    // 400: 부서 등록 시 이미 존재하는 부서명이 있을 경우 발생하는 예외 처리
+    // 400: 비즈니스 로직 검증 실패 시 발생하는 예외 처리
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException ex) {
+        ErrorResponse error = new ErrorResponse(
+            Instant.now(),
+            HttpStatus.BAD_REQUEST.value(),
+            "잘못된 요청입니다.",
+            ex.getMessage()
+        );
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    // 400: 등록하는 것이 이미 존재할 경우 발생하는 예외 처리
     @ExceptionHandler(DuplicateException.class)
     public ResponseEntity<ErrorResponse> handleDuplicate(DuplicateException ex) {
         ErrorResponse error = new ErrorResponse(


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #64

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 삭제 요청을 처리하는 컨트롤러 메서드를 작성하고, 삭제 시 발생할 수 있는 예외 처리 로직을 구현
- 존재하지 않는 부서 ID 요청 시 404, 소속 직원 존재 시 400 응답을 반환

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- DELETE /api/departments/{id} 컨트롤러 메서드 작성
  - @PathVariable Long id로 삭제 요청 처리
  - 서비스 호출 후 204 No Content 반환
- 존재하지 않는 부서 ID 요청 시 404 예외 처리
  - 기존 EntityNotFoundException 활용 가능
- 소속 직원 존재 시 400 예외 처리
  - IllegalStateException 또는 공통 예외 처리 방식 적용
- GlobalExceptionHandler에 필요한 예외 처리 추가
