### PR TITLE
[안재관 | 0424] Feature/77 부서 상세 조회 서비스 및 직원 수 포함 로직 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/service/DepartmentService.java
+++ b/src/main/java/com/team01/hrbank/service/DepartmentService.java
@@ -8,6 +8,8 @@ public interface DepartmentService {
 
     DepartmentDto createDepartment(DepartmentCreateRequest request);
 
+    DepartmentDto getDepartment(Long departmentId);
+
     DepartmentDto updateDepartment(Long departmentId, DepartmentUpdateRequest request);
 
     void deleteDepartment(Long departmentId);

--- a/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/team01/hrbank/service/impl/DepartmentServiceImpl.java
@@ -37,9 +37,20 @@ public class DepartmentServiceImpl implements DepartmentService {
             request.establishedDate()
         );
         Department savedDepartment = departmentRepository.save(department);
+        Long employeeCount = employeeRepository.countByDepartmentId(savedDepartment.getId());
 
-        // 나중에 0L 부분을 실제 직원을 조회한 값으로 바꿔야 합니다. + 조회 로직까지 추가
-        return departmentMapper.toDto(savedDepartment, 0L);
+        return departmentMapper.toDto(savedDepartment, employeeCount);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DepartmentDto getDepartment(Long departmentId) {
+        Department department = departmentRepository.findById(departmentId)
+            .orElseThrow(() -> new EntityNotFoundException(DEPARTMENT, departmentId));
+
+        Long employeeCount = employeeRepository.countByDepartmentId(departmentId);
+
+        return departmentMapper.toDto(department, employeeCount);
     }
 
     @Override
@@ -53,8 +64,9 @@ public class DepartmentServiceImpl implements DepartmentService {
         }
 
         department.update(request.name(), request.description(), request.establishedDate());
+        Long employeeCount = employeeRepository.countByDepartmentId(departmentId);
 
-        return departmentMapper.toDto(department, 0L);
+        return departmentMapper.toDto(department, employeeCount);
     }
 
     @Override


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #77 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 상세 정보를 조회하기 위한 서비스 로직을 구현
- 부서 ID를 기준으로 단건 조회, 직원 수 정보도 포함

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- `DepartmentService`에 상세 조회 메서드 정의
- 부서 ID로 단건 조회 (존재하지 않으면 예외)
- 직원 수 계산 로직 추가
  - `employeeRepository.countByDepartmentId(id)` 활용
- 응답용 DTO(`DepartmentDto`) 재사용 또는 수정 검토
- Mapper를 통해 응답 DTO 변환
