### PR TITLE
[안재관 | 0424] Feature/78 부서 상세 조회 API 및 예외 처리 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/controller/DepartmentController.java
+++ b/src/main/java/com/team01/hrbank/controller/DepartmentController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,7 +28,19 @@ public class DepartmentController {
         @Valid @RequestBody DepartmentCreateRequest request) {
 
         DepartmentDto response = departmentService.createDepartment(request);
-        return ResponseEntity.ok(response); // 200 OK 응답
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DepartmentDto> getDepartment(@PathVariable Long id) {
+        DepartmentDto response = departmentService.getDepartment(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDepartment(@PathVariable Long id) {
+        departmentService.deleteDepartment(id);
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/{id}")
@@ -37,12 +50,6 @@ public class DepartmentController {
 
         DepartmentDto response = departmentService.updateDepartment(id, request);
         return ResponseEntity.ok(response);
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteDepartment(@PathVariable Long id) {
-        departmentService.deleteDepartment(id);
-        return ResponseEntity.noContent().build();
     }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #78 
---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 상세 정보를 조회하는 컨트롤러 메서드를 작성하고, 요청한 부서가 존재하지 않을 경우 404 예외를 반환하는 처리를 구현

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- GET `/api/departments/{id}` 컨트롤러 메서드 작성
  - `@PathVariable Long id`로 요청 처리
  - `DepartmentDto`를 응답으로 반환
- 부서 미존재 시 `EntityNotFoundException` 발생
- GlobalExceptionHandler에서 해당 예외를 404로 처리
