### PR TITLE
[안재관 | 0425] Feature/95 부서 목록 조회 검색, 정렬 및 커서 기반 페이징 로직 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
+++ b/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
@@ -7,7 +7,6 @@ public interface DepartmentRepository extends JpaRepository<Department, Long> {
 
     boolean existsByName(String name);
 
-    // 수정 시, 자기 자신(ID)을 제외한 중복 체크
-    boolean existsByNameAndIdNot(String name, Long id);
+    boolean existsByNameAndIdNot(String name, Long id); // 수정 시, 자기 자신(ID)을 제외한 중복 체크
 
 }

--- a/src/main/java/com/team01/hrbank/repository/custom/DepartmentQueryRepository.java
+++ b/src/main/java/com/team01/hrbank/repository/custom/DepartmentQueryRepository.java
@@ -1,0 +1,11 @@
+package com.team01.hrbank.repository.custom;
+
+import com.team01.hrbank.dto.department.DepartmentDto;
+import java.util.List;
+
+public interface DepartmentQueryRepository {
+    List<DepartmentDto> findDepartmentsWithConditions(
+        String nameOrDescription, String sortField, String sortDirection,
+        Long idAfter, int size
+    );
+}

--- a/src/main/java/com/team01/hrbank/repository/impl/DepartmentQueryRepositoryImpl.java
+++ b/src/main/java/com/team01/hrbank/repository/impl/DepartmentQueryRepositoryImpl.java
@@ -1,0 +1,74 @@
+package com.team01.hrbank.repository.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team01.hrbank.dto.department.DepartmentDto;
+import com.team01.hrbank.entity.Department;
+import com.team01.hrbank.entity.QDepartment;
+import com.team01.hrbank.mapper.DepartmentMapper;
+import com.team01.hrbank.repository.EmployeeRepository;
+import com.team01.hrbank.repository.custom.DepartmentQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DepartmentQueryRepositoryImpl implements DepartmentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QDepartment department = QDepartment.department;
+    private final EmployeeRepository employeeRepository;
+    private final DepartmentMapper departmentMapper;
+
+    @Override
+    public List<DepartmentDto> findDepartmentsWithConditions(
+        String nameOrDescription, String sortField, String sortDirection,
+        Long idAfter, int size
+    ) {
+
+        BooleanBuilder whereClause = new BooleanBuilder(); // 동적 where 조건 (처음에 비어있는 조건 생성)
+
+        // 검색 조건 처리: name 또는 description 부분 일치 검색
+        if (nameOrDescription != null && !nameOrDescription.isEmpty()) {
+            whereClause.and(department.name.containsIgnoreCase(nameOrDescription)
+                .or(department.description.containsIgnoreCase(nameOrDescription)));
+        }
+
+        // 정렬 필드 지정
+        OrderSpecifier<?> orderSpecifier;
+        if ("name".equalsIgnoreCase(sortField)) {
+            orderSpecifier = "desc".equalsIgnoreCase(sortField) ?
+                department.name.desc() : department.name.asc();
+        } else {
+            orderSpecifier = "desc".equalsIgnoreCase(sortField) ?
+                department.establishedDate.desc() : department.establishedDate.asc();
+        }
+
+        // 커서 기반 페이지 네이션
+        if (idAfter != null) {
+            if ("desc".equalsIgnoreCase(sortDirection)) {
+                whereClause.and(department.id.lt(idAfter)); // 내림차순이면 id < idAfter
+            } else {
+                whereClause.and(department.id.gt(idAfter)); // 오름차순이면 id > idAfter
+            }
+        }
+
+        // QueryDSL 쿼리 실행: 부서 목록 조회
+        List<Department> departments = queryFactory
+            .selectFrom(department)
+            .where(whereClause)
+            .orderBy(orderSpecifier)
+            .limit(size + 1) // 다음 페이지 존재 여부 확인 (size + 1개일 때 hasNext = true, 그렇지 않으면 false)
+            .fetch();
+
+        // 직원 수 계산 및 DTO 변환
+        return departments.stream()
+            .map(dep -> {
+                Long employeeCount = employeeRepository.countByDepartmentId(dep.getId());
+                return departmentMapper.toDto(dep, employeeCount);
+            })
+            .toList();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #95 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 목록 조회 시 검색 조건(nameOrDescription), 정렬 조건, 커서 기반 페이지네이션을 처리하는 로직을 구현
- 서비스 레이어에서 조건에 맞는 부서 목록을 조회할 수 있도록 쿼리를 작성

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- 검색 파라미터 처리
  - `nameOrDescription` 부분 일치 검색
  - 정렬: `sortField` (name 또는 establishedDate), `sortDirection` (asc, desc)
- 커서 기반 페이지네이션 로직 구현
  - idAfter, size 파라미터 처리
  - 정렬 방향에 따라 idAfter 조건 다르게 적용 (asc: gt, desc: lt)
  - limit(size + 1) 방식으로 hasNext 판단 가능하게 구현
- 커서 기반 페이징 쿼리 작성 (QueryDSL 사용)
- 목록 조회 쿼리 작성
- 직원 수 계산: 각 부서별 `employeeRepository.countByDepartmentId()` 활용
