### PR TITLE
[안재관 | 0425] Feature/96 부서 목록 조회 컨트롤러 및 페이징,검색,정렬 파라미터 처리 구현

### DIFF
--- a/src/main/java/com/team01/hrbank/controller/DepartmentController.java
+++ b/src/main/java/com/team01/hrbank/controller/DepartmentController.java
@@ -1,10 +1,13 @@
 package com.team01.hrbank.controller;
 
+import com.team01.hrbank.dto.department.CursorPageResponseDepartmentDto;
 import com.team01.hrbank.dto.department.DepartmentCreateRequest;
 import com.team01.hrbank.dto.department.DepartmentDto;
 import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
 import com.team01.hrbank.service.DepartmentService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +26,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class DepartmentController {
 
     private final DepartmentService departmentService;
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponseDepartmentDto> getDepartments(
+        @RequestParam(required = false) String nameOrDescription,
+        @RequestParam(required = false) Long idAfter,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+        @RequestParam(defaultValue = "establishedDate") String sortField,
+        @RequestParam(defaultValue = "asc") String sortDirection
+    ) {
+        CursorPageResponseDepartmentDto response = departmentService.getDepartments(
+            nameOrDescription, idAfter, cursor, size, sortField, sortDirection
+        );
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping
     public ResponseEntity<DepartmentDto> createDepartment(

--- a/src/main/java/com/team01/hrbank/dto/department/CursorPageResponseDepartmentDto.java
+++ b/src/main/java/com/team01/hrbank/dto/department/CursorPageResponseDepartmentDto.java
@@ -1,0 +1,14 @@
+package com.team01.hrbank.dto.department;
+
+import java.util.List;
+
+public record CursorPageResponseDepartmentDto(
+    List<DepartmentDto> content,
+    String nextCursor,
+    Long nextIdAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
+++ b/src/main/java/com/team01/hrbank/repository/DepartmentRepository.java
@@ -1,9 +1,11 @@
 package com.team01.hrbank.repository;
 
 import com.team01.hrbank.entity.Department;
+import com.team01.hrbank.repository.custom.DepartmentQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DepartmentRepository extends JpaRepository<Department, Long> {
+public interface DepartmentRepository extends JpaRepository<Department, Long>,
+    DepartmentQueryRepository {
 
     boolean existsByName(String name);
 

--- a/src/main/java/com/team01/hrbank/repository/custom/DepartmentQueryRepository.java
+++ b/src/main/java/com/team01/hrbank/repository/custom/DepartmentQueryRepository.java
@@ -4,8 +4,8 @@ import com.team01.hrbank.dto.department.DepartmentDto;
 import java.util.List;
 
 public interface DepartmentQueryRepository {
+
     List<DepartmentDto> findDepartmentsWithConditions(
-        String nameOrDescription, String sortField, String sortDirection,
-        Long idAfter, int size
+        String nameOrDescription, Long idAfter, String sortField, String sortDirection, int size
     );
 }

--- a/src/main/java/com/team01/hrbank/repository/impl/DepartmentQueryRepositoryImpl.java
+++ b/src/main/java/com/team01/hrbank/repository/impl/DepartmentQueryRepositoryImpl.java
@@ -24,8 +24,7 @@ public class DepartmentQueryRepositoryImpl implements DepartmentQueryRepository 
 
     @Override
     public List<DepartmentDto> findDepartmentsWithConditions(
-        String nameOrDescription, String sortField, String sortDirection,
-        Long idAfter, int size
+        String nameOrDescription, Long idAfter, String sortField, String sortDirection, int size
     ) {
 
         BooleanBuilder whereClause = new BooleanBuilder(); // 동적 where 조건 (처음에 비어있는 조건 생성)

--- a/src/main/java/com/team01/hrbank/service/DepartmentService.java
+++ b/src/main/java/com/team01/hrbank/service/DepartmentService.java
@@ -1,5 +1,6 @@
 package com.team01.hrbank.service;
 
+import com.team01.hrbank.dto.department.CursorPageResponseDepartmentDto;
 import com.team01.hrbank.dto.department.DepartmentCreateRequest;
 import com.team01.hrbank.dto.department.DepartmentDto;
 import com.team01.hrbank.dto.department.DepartmentUpdateRequest;
@@ -13,4 +14,13 @@ public interface DepartmentService {
     DepartmentDto updateDepartment(Long departmentId, DepartmentUpdateRequest request);
 
     void deleteDepartment(Long departmentId);
+
+    CursorPageResponseDepartmentDto getDepartments(
+        String nameOrDescription,
+        Long idAfter,
+        String cursor,
+        int size,
+        String sortField,
+        String sortDirection
+    );
 }

--- a/src/main/java/com/team01/hrbank/util/CursorUtil.java
+++ b/src/main/java/com/team01/hrbank/util/CursorUtil.java
@@ -1,0 +1,37 @@
+package com.team01.hrbank.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Base64;
+import java.util.Map;
+
+public class CursorUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 커서를 디코딩해서 idAfter 값 추출
+    public static Long decodeCursor(String cursor) {
+        try {
+            if (cursor == null || cursor.isEmpty()) {
+                return null;
+            }
+            byte[] decodedBytes = Base64.getDecoder().decode(cursor);
+            String json = new String(decodedBytes);
+            Map<String, Object> map = objectMapper.readValue(json, Map.class);
+            return ((Number) map.get("id")).longValue();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 커서 값입니다.", e);
+        }
+    }
+
+    // idAfter 값을 커서로 인코딩
+    public static String encodeCursor(Long idAfter) {
+        try {
+            if (idAfter == null) {
+                return null;
+            }
+            String json = objectMapper.writeValueAsString(Map.of("id", idAfter));
+            return Base64.getEncoder().encodeToString(json.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("커서 인코딩 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #96 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 부서 목록을 조회하는 컨트롤러 메서드를 작성하고, 조회된 부서 목록을 응답 DTO로 변환하여 반환하는 로직 구현
- 검색, 정렬, 커서 기반 페이지네이션 파라미터 처리 및 요청 파라미터 검증, 예외 처리도 포함
- 특히, cursor 파라미터 인코딩/디코딩 로직을 포함하여 API 명세에 맞는 페이징 형태를 완벽히 지원

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- GET /api/departments 컨트롤러 메서드 작성
- 검색, 정렬, 페이징 파라미터 처리
  - nameOrDescription, sortField, sortDirection, idAfter, size, cursor
  - cursor 파라미터를 디코딩하여 idAfter로 변환 처리
- 서비스 레이어에서 커스텀 레포지토리 호출
  - findDepartmentsWithConditions(...) 메서드 활용
- 결과 리스트를 응답 DTO로 반환
  - DepartmentDto 재사용 또는 필요 시 목록 전용 DTO 설계 검토
- 페이징 메타 정보 계산
  - hasNext, nextIdAfter 처리
  - nextIdAfter 값을 인코딩하여 nextCursor 생성
- 응답 형태
  - CursorPageResponseDepartmentDto 포맷으로 반환
- 예외 처리
  - 잘못된 파라미터 입력 시 400 Bad Request 응답 처리
